### PR TITLE
decouple mapping actions from http methods

### DIFF
--- a/apis/disposablerequest/v1alpha1/status_setters.go
+++ b/apis/disposablerequest/v1alpha1/status_setters.go
@@ -26,7 +26,7 @@ func (d *DisposableRequest) SetError(err error) {
 	}
 }
 
-func (d *DisposableRequest) SetRequestDetails(url, method, body string, headers map[string][]string) {
+func (d *DisposableRequest) SetRequestDetails(url, _, method, body string, headers map[string][]string) {
 	d.Status.RequestDetails.Body = body
 	d.Status.RequestDetails.URL = url
 	d.Status.RequestDetails.Headers = headers

--- a/apis/request/v1alpha1/request_types.go
+++ b/apis/request/v1alpha1/request_types.go
@@ -43,6 +43,9 @@ type Mapping struct {
 	Body    string              `json:"body,omitempty"`
 	URL     string              `json:"url"`
 	Headers map[string][]string `json:"headers,omitempty"`
+
+	// +kubebuilder:validation:Enum=CREATE;GET;UPDATE;DELETE
+	Action string `json:"action"`
 }
 
 type Payload struct {

--- a/apis/request/v1alpha1/status_setters.go
+++ b/apis/request/v1alpha1/status_setters.go
@@ -26,11 +26,12 @@ func (d *Request) ResetFailures() {
 	d.Status.Error = ""
 }
 
-func (d *Request) SetRequestDetails(url, method, body string, headers map[string][]string) {
+func (d *Request) SetRequestDetails(url, action, method, body string, headers map[string][]string) {
 	d.Status.RequestDetails.Body = body
 	d.Status.RequestDetails.URL = url
 	d.Status.RequestDetails.Headers = headers
 	d.Status.RequestDetails.Method = method
+	d.Status.RequestDetails.Action = action
 }
 
 func (d *Request) SetCache(statusCode int, headers map[string][]string, body string) {

--- a/internal/controller/request/utils.go
+++ b/internal/controller/request/utils.go
@@ -4,9 +4,9 @@ import (
 	"github.com/crossplane-contrib/provider-http/apis/request/v1alpha1"
 )
 
-func getMappingByMethod(requestParams *v1alpha1.RequestParameters, method string) (*v1alpha1.Mapping, bool) {
+func getMappingByAction(requestParams *v1alpha1.RequestParameters, action Action) (*v1alpha1.Mapping, bool) {
 	for _, mapping := range requestParams.Mappings {
-		if mapping.Method == method {
+		if mapping.Action == string(action) {
 			return &mapping, true
 		}
 	}

--- a/internal/controller/request/utils_test.go
+++ b/internal/controller/request/utils_test.go
@@ -88,13 +88,13 @@ func Test_getMappingByMethod(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got, ok := getMappingByMethod(tc.args.requestParams, tc.args.method)
+			got, ok := getMappingByAction(tc.args.requestParams, tc.args.method)
 			if diff := cmp.Diff(tc.want.mapping, got); diff != "" {
-				t.Fatalf("getMappingByMethod(...): -want result, +got result: %s", diff)
+				t.Fatalf("getMappingByAction(...): -want result, +got result: %s", diff)
 			}
 
 			if diff := cmp.Diff(tc.want.ok, ok); diff != "" {
-				t.Fatalf("getMappingByMethod(...): -want result, +got result: %s", diff)
+				t.Fatalf("getMappingByAction(...): -want result, +got result: %s", diff)
 			}
 		})
 	}

--- a/internal/utils/set_status.go
+++ b/internal/utils/set_status.go
@@ -19,6 +19,8 @@ type RequestResource struct {
 	HttpResponse   httpClient.HttpResponse
 	HttpRequest    httpClient.HttpRequest
 	LocalClient    client.Client
+
+	Action string
 }
 
 func (rr *RequestResource) SetStatusCode() SetRequestStatusFunc {
@@ -55,7 +57,7 @@ func (rr *RequestResource) SetRequestDetails() SetRequestStatusFunc {
 	return func() {
 		if resp, ok := rr.Resource.(RequestDetailsSetter); ok {
 			if rr.HttpRequest.Method != "" {
-				resp.SetRequestDetails(rr.HttpRequest.URL, rr.HttpRequest.Method, rr.HttpRequest.Body, rr.HttpRequest.Headers)
+				resp.SetRequestDetails(rr.HttpRequest.URL, rr.Action, rr.HttpRequest.Method, rr.HttpRequest.Body, rr.HttpRequest.Headers)
 			}
 		}
 	}
@@ -116,7 +118,7 @@ type ResetFailures interface {
 }
 
 type RequestDetailsSetter interface {
-	SetRequestDetails(url, method, body string, headers map[string][]string)
+	SetRequestDetails(url, action, method, body string, headers map[string][]string)
 }
 
 func SetRequestResourceStatus(rr RequestResource, statusFuncs ...SetRequestStatusFunc) error {

--- a/package/crds/http.crossplane.io_requests.yaml
+++ b/package/crds/http.crossplane.io_requests.yaml
@@ -81,6 +81,13 @@ spec:
                   mappings:
                     items:
                       properties:
+                        action:
+                          enum:
+                          - CREATE
+                          - GET
+                          - UPDATE
+                          - DELETE
+                          type: string
                         body:
                           type: string
                         headers:
@@ -99,6 +106,7 @@ spec:
                         url:
                           type: string
                       required:
+                      - action
                       - method
                       - url
                       type: object
@@ -365,6 +373,13 @@ spec:
                 type: integer
               requestDetails:
                 properties:
+                  action:
+                    enum:
+                    - CREATE
+                    - GET
+                    - UPDATE
+                    - DELETE
+                    type: string
                   body:
                     type: string
                   headers:
@@ -383,6 +398,7 @@ spec:
                   url:
                     type: string
                 required:
+                - action
                 - method
                 - url
                 type: object


### PR DESCRIPTION
### Description of your changes

Many REST API are opinionated and may not match current mapping on http methods , which may become an implementation blocker issue. 
Proposed change defines static place holders for mapping actions: CREATE/GET/UPDATE/DELETE , this way http method gets free to implementation from user specification, as example: Update action can be performed with PUT or POST.


- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
